### PR TITLE
fix: make bot config kebab cased

### DIFF
--- a/.github/ubiquibot-config.yml
+++ b/.github/ubiquibot-config.yml
@@ -1,7 +1,7 @@
 ---
-autoPayMode: true
-baseMultiplier: 1000
-timeLabels:
+auto-pay-mode: true
+base-multiplier: 1000
+time-labels:
 - name: 'Time: <1 Hour'
   weight: 0.125
   value: 3600
@@ -22,7 +22,7 @@ timeLabels:
   weight: 4
   value: 2592000
   target: 'Price: 400+ USD'
-priorityLabels:
+priority-labels:
 - name: 'Priority: 0 (Normal)'
   weight: 1
   target: 'Price: 100+ USD'


### PR DESCRIPTION
This PR updates the bot's config to use kebab cased param names