### PR TITLE
ci: print deploy URLs in a single comment

### DIFF
--- a/utils/print-deployments-logs.js
+++ b/utils/print-deployments-logs.js
@@ -77,13 +77,12 @@ module.exports = async ({ github, context, fs, customDomain }) => {
   const editExistingPRComment = async () => {
     const { body: botBody, id: commentId } = botCommentsArray[0];
     let commentBody = `${GMTConverter(defaultBody)}\n` + `${GMTConverter(botBody)}`;
-    const sortCommentBody = sortComments(commentBody);
-    verifyInput(sortCommentBody) &&
+    verifyInput(commentBody) &&
       (await github.rest.issues.updateComment({
         owner: context.repo.owner,
         repo: context.repo.repo,
         comment_id: commentId,
-        body: sortCommentBody,
+        body: commentBody,
       }));
   };
 
@@ -103,8 +102,7 @@ module.exports = async ({ github, context, fs, customDomain }) => {
     botCommentsArray.forEach(({ body }) => {
       commentBody = commentBody + `${GMTConverter(body)}\n`;
     });
-    const sortCommentBody = sortComments(commentBody);
-    await createNewPRComment(sortCommentBody);
+    await createNewPRComment(commentBody);
     await deleteExistingPRComments();
   };
 


### PR DESCRIPTION
When we removed timestamps from deploy URL name the `sortComments()` function began to return empty results thus making the deployment URLs empty. This PR fixes it.

So after this PR all deployment URLs fit in a single comment with commit messages ([example](https://github.com/rndquu/pay.ubq.fi/pull/23#issuecomment-1674531452))

