### PR TITLE
ci: run tallyRepo.yml on workflow_dispatch

### DIFF
--- a/.github/workflows/tallyRepo.yml
+++ b/.github/workflows/tallyRepo.yml
@@ -1,12 +1,7 @@
 name: Run UBQ Airdrop CLI
 
 on:
-  push:
-    branches:
-      - master
-      - main
-      - development
-      - airdrop-cli
+  workflow_dispatch:
 
 jobs:
   run-cli:


### PR DESCRIPTION
As far as I understand there is no need run the "Run UBQ Airdrop CLI" workflow on every push which results in an [error](https://github.com/ubiquity/.github/actions/runs/8327387347/job/22784944594) right now