### PR TITLE
ci: use actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/tallyRepo.yml
+++ b/.github/workflows/tallyRepo.yml
@@ -25,7 +25,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload CSV Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ubq-airdrop-csv
           path: |


### PR DESCRIPTION
Artifact actions v3 will be deprecated by December 5, 2024. After this date using v3 of these actions will result in a workflow failure.

This PR upgrades usage of `actions/upload-artifact` to v4.

Migration guide:  https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md